### PR TITLE
add api.export so that the UniUtils object is available on the client

### DIFF
--- a/package.js
+++ b/package.js
@@ -2,7 +2,7 @@
 
 Package.describe({
     name: 'vazco:universe-reactive-queries',
-    version: '1.0.0',
+    version: '1.0.1',
     summary: 'Reactive url query parameters (works with iron router)',
     git: 'https://github.com/vazco/meteor-universe-reactive-queries'
 });
@@ -12,5 +12,5 @@ Package.onUse(function (api) {
     api.use(['vazco:universe-utilities@1.1.6', 'iron:router@1.0.9 || =0.9.4', 'underscore', 'tracker', 'templating'], 'client');
     api.addFiles(['deparam.js'], 'client');
     api.addFiles(['query.js'], 'client');
-
+    api.export('UniUtils', 'client');
 });


### PR DESCRIPTION
The UniUtils object isn't available clientside when only adding this package in meteor.  I forked and am using a cloned version of your package in my app.  Pending this PR.
